### PR TITLE
delete post function

### DIFF
--- a/js/api/posts/delete-posts/delete-post.mjs
+++ b/js/api/posts/delete-posts/delete-post.mjs
@@ -1,0 +1,25 @@
+import { API_BASE_URL } from "../../../utilities/base-url.mjs";
+
+export async function deletePost(postId) {
+  const jwtToken = localStorage.getItem("jwtToken");
+  if (!jwtToken) throw new Error("Token not found.");
+
+  const response = await fetch(`${API_BASE_URL}/posts/${postId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${jwtToken}` },
+  });
+
+  if (!response.ok) {
+    console.error("Post deletion failed:", response);
+    throw new Error(`HTTP error. Status: ${response.status}`);
+  }
+  console.log("Post deletion succeeded:", response);
+}
+
+export function updateLocalStorageDeleted(postId) {
+  let posts = JSON.parse(localStorage.getItem("posts")) || [];
+  const initialPostCount = posts.length;
+  posts = posts.filter((post) => post.id !== postId);
+  console.log(`Deleted ${initialPostCount - posts.length} posts from localStorage.`);
+  localStorage.setItem("posts", JSON.stringify(posts));
+}

--- a/js/api/posts/new-posts/render-new-post.mjs
+++ b/js/api/posts/new-posts/render-new-post.mjs
@@ -1,3 +1,4 @@
+import { deletePost, updateLocalStorageDeleted } from "../delete-posts/delete-post.mjs";
 import { toggleEditForm } from "../edit-posts/edit-post.mjs";
 import { handleEditFormSubmission } from "../edit-posts/post-ui-updates.mjs";
 
@@ -10,15 +11,18 @@ export async function renderMyPost(newPost) {
     const titleElement = document.createElement("h2");
     const bodyElement = document.createElement("p");
     const editButton = document.createElement("button");
+    const deleteButton = document.createElement("button");
 
     // Setting content
     titleElement.textContent = title;
     bodyElement.textContent = body;
     editButton.textContent = "Edit";
+    deleteButton.textContent = "Delete";
 
-    // Appending child elements
-    postElement.appendChild(titleElement);
-    postElement.appendChild(bodyElement);
+    // Style edit and delete buttons
+
+    editButton.className = "btn btn-primary";
+    deleteButton.className = "btn btn-secondary m-4";
 
     // Handling media element
 
@@ -28,14 +32,22 @@ export async function renderMyPost(newPost) {
       postElement.appendChild(mediaElement);
     }
 
-    // Creating and handling edit Form
+    // Appending child elements
+    postElement.appendChild(titleElement);
+    postElement.appendChild(bodyElement);
+
+    // Creating and handling edit form and delete
     const editForm = createEditForm(newPost.title, newPost.body, newPost.media, newPost.id, handleEditFormSubmission, titleElement, bodyElement, mediaElement);
     editButton.onclick = () => toggleEditForm(editForm);
+    deleteButton.onclick = () => showDeleteModal(id);
 
     postElement.appendChild(editButton);
     postElement.appendChild(editForm);
+    postElement.appendChild(deleteButton);
 
     document.getElementById("myPostsContainer").appendChild(postElement);
+
+    createDeleteModal(id, postElement); // modal for the delete action
   } catch (error) {
     console.error("Error rendering post:", error);
   }
@@ -76,4 +88,88 @@ export function savePost(newPost) {
   let posts = JSON.parse(localStorage.getItem("posts")) || [];
   posts.push(newPost);
   localStorage.setItem("posts", JSON.stringify(posts));
+}
+
+function createDeleteModal(postId, postElement) {
+  const modal = document.createElement("div");
+  modal.classList.add("modal", "fade");
+  modal.id = `deleteModal${postId}`;
+  modal.setAttribute("tabindex", "-1");
+  modal.setAttribute("aria-labelledby", `deleteModalLabel${postId}`);
+  modal.setAttribute("aria-hidden", "true");
+
+  const modalDialog = document.createElement("div");
+  modalDialog.classList.add("modal-dialog");
+
+  const modalContent = document.createElement("div");
+  modalContent.classList.add("modal-content");
+
+  const modalHeader = document.createElement("div");
+  modalHeader.classList.add("modal-header");
+
+  const modalTitle = document.createElement("h5");
+  modalTitle.classList.add("modal-title");
+  modalTitle.id = `deleteModalLabel${postId}`;
+  modalTitle.textContent = "Delete post";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.classList.add("btn-close");
+  closeButton.setAttribute("data-bs-dismiss", "modal");
+  closeButton.setAttribute("aria-label", "Close");
+
+  modalHeader.appendChild(modalTitle);
+  modalHeader.appendChild(closeButton);
+
+  const modalBody = document.createElement("div");
+  modalBody.classList.add("modal-body");
+  modalBody.textContent = "Are you sure you want to delete your post?";
+
+  const modalFooter = document.createElement("div");
+  modalFooter.classList.add("modal-footer");
+
+  const cancelButton = document.createElement("button");
+  cancelButton.type = "button";
+  cancelButton.classList.add("btn", "btn-secondary");
+  cancelButton.setAttribute("data-bs-dismiss", "modal");
+  cancelButton.textContent = "Cancel";
+
+  const confirmDeleteButton = document.createElement("button");
+  confirmDeleteButton.type = "button";
+  confirmDeleteButton.classList.add("btn", "btn-danger");
+  confirmDeleteButton.id = `confirmDeleteButton${postId}`;
+  confirmDeleteButton.textContent = "Delete";
+
+  modalFooter.appendChild(cancelButton);
+  modalFooter.appendChild(confirmDeleteButton);
+
+  modalContent.appendChild(modalHeader);
+  modalContent.appendChild(modalBody);
+  modalContent.appendChild(modalFooter);
+
+  modalDialog.appendChild(modalContent);
+  modal.appendChild(modalDialog);
+
+  document.body.appendChild(modal);
+
+  document.getElementById(`confirmDeleteButton${postId}`).onclick = async () => {
+    console.log(`Trying to delete a post with ID: ${postId}`);
+    try {
+      await deletePost(postId);
+      postElement.remove();
+      updateLocalStorageDeleted(postId);
+      const deleteModalElement = document.getElementById(`deleteModal${postId}`);
+      const deleteModal = new bootstrap.Modal(deleteModalElement);
+      console.log(deleteModal);
+      deleteModal.hide();
+      console.log("Your post was deleted.");
+    } catch (error) {
+      console.error("There was an error deleting post:", error);
+    }
+  };
+}
+
+function showDeleteModal(postId) {
+  const deleteModal = new bootstrap.Modal(document.getElementById(`deleteModal${postId}`));
+  deleteModal.show();
 }


### PR DESCRIPTION
**Initiating deletion of post**
- user clicks the "Delete button", triggers `showDeleteModal(postId)`.
**Confirming deletion of post**
- Modal pops up, asks user to confirm "Delete" or "Cancel".
- `createDeleteModal(postId, postElement)`: modal is dynamically generated and appended to HTML using the postID,
`confirmDeleteButton.onclick`: user clicks to confirm deletion.
**Executing deletion on confirmation**
- `deletePost(postId)`: sends a DELETE HTTP request to API, using JWT token from localStorage for authorization.
`postElement.remove()`: Post is removed from the UI.
`updateLocalStorageDeleted(postId)`: Post is removed from localStorage.

`render-new-post.mjs` handles UI rendering, invokes delete modal and local storage update.
`delete-post.mjs` handles the API request for deleting and updating local storage. 